### PR TITLE
This closes #1416

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -310,9 +310,10 @@ type Cell struct {
 // RowOpts define the options for the set row, it can be used directly in
 // StreamWriter.SetRow to specify the style and properties of the row.
 type RowOpts struct {
-	Height  float64
-	Hidden  bool
-	StyleID int
+	Height       float64
+	Hidden       bool
+	StyleID      int
+	OutlineLevel int
 }
 
 // marshalAttrs prepare attributes of the row.
@@ -337,6 +338,11 @@ func (r *RowOpts) marshalAttrs() (strings.Builder, error) {
 		attrs.WriteString(` ht="`)
 		attrs.WriteString(strconv.FormatFloat(r.Height, 'f', -1, 64))
 		attrs.WriteString(`" customHeight="1"`)
+	}
+	if r.OutlineLevel > 0 && r.OutlineLevel < 8 {
+		attrs.WriteString(` outlineLevel="`)
+		attrs.WriteString(strconv.Itoa(r.OutlineLevel))
+		attrs.WriteString(`"`)
 	}
 	if r.Hidden {
 		attrs.WriteString(` hidden="1"`)

--- a/stream_test.go
+++ b/stream_test.go
@@ -358,3 +358,31 @@ func TestStreamSetCellValFunc(t *testing.T) {
 	assert.NoError(t, sw.setCellValFunc(c, nil))
 	assert.NoError(t, sw.setCellValFunc(c, complex64(5+10i)))
 }
+
+func TestStreamWriterOutlineLevel(t *testing.T) {
+	file := NewFile()
+	streamWriter, err := file.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+
+	// Test set outlineLevel in row.
+	assert.NoError(t, streamWriter.SetRow("A1", nil, RowOpts{OutlineLevel: 1}))
+	assert.NoError(t, streamWriter.SetRow("A2", nil, RowOpts{OutlineLevel: 7}))
+	assert.NoError(t, streamWriter.SetRow("A3", nil, RowOpts{OutlineLevel: 8}))
+
+	assert.NoError(t, streamWriter.Flush())
+	// Save spreadsheet by the given path.
+	assert.NoError(t, file.SaveAs(filepath.Join("test", "TestStreamWriterSetRowOutlineLevel.xlsx")))
+
+	file, err = OpenFile(filepath.Join("test", "TestStreamWriterSetRowOutlineLevel.xlsx"))
+	assert.NoError(t, err)
+	level, err := file.GetRowOutlineLevel("Sheet1", 1)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(1), level)
+	level, err = file.GetRowOutlineLevel("Sheet1", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(7), level)
+	level, err = file.GetRowOutlineLevel("Sheet1", 3)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(0), level)
+	assert.NoError(t, file.Close())
+}


### PR DESCRIPTION
# PR Details

Close issued #1416

## Description

- Add new field OutlineLevel to struct RowOpts
- Add in marshalAttrs new code for OutlineLevel

## Related Issue
[<!--- Issued #1416 -->](https://github.com/qax-os/excelize/issues/1416)

## Motivation and Context

This change adding outlinelevel in xlsx document

## How Has This Been Tested

One of the tests is a visual check of the result in the received file.

The second one is TestStreamWriterOutlineLevel in stream_test.go

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
