### PR TITLE
This closes #1416

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -329,6 +329,10 @@ func (r *RowOpts) marshalAttrs() (strings.Builder, error) {
 		err = ErrMaxRowHeight
 		return attrs, err
 	}
+	if r.OutlineLevel > 7 {
+		err = ErrOutlineLevel
+		return attrs, err
+	}
 	if r.StyleID > 0 {
 		attrs.WriteString(` s="`)
 		attrs.WriteString(strconv.Itoa(r.StyleID))

--- a/stream_test.go
+++ b/stream_test.go
@@ -367,7 +367,7 @@ func TestStreamWriterOutlineLevel(t *testing.T) {
 	// Test set outlineLevel in row.
 	assert.NoError(t, streamWriter.SetRow("A1", nil, RowOpts{OutlineLevel: 1}))
 	assert.NoError(t, streamWriter.SetRow("A2", nil, RowOpts{OutlineLevel: 7}))
-	assert.NoError(t, streamWriter.SetRow("A3", nil, RowOpts{OutlineLevel: 8}))
+	assert.ErrorIs(t, ErrOutlineLevel, streamWriter.SetRow("A3", nil, RowOpts{OutlineLevel: 8}))
 
 	assert.NoError(t, streamWriter.Flush())
 	// Save spreadsheet by the given path.


### PR DESCRIPTION
- Add return error ErrOutlineLevel

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added return ErrOutlineLevel when RowOpts.OutlineLevel > 7
<!--- Describe your changes in detail -->

## Related Issue
Issue #1416
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
